### PR TITLE
fix(chunking): include final partial chunk in output

### DIFF
--- a/DoclingSharp/DocumentChunker.cs
+++ b/DoclingSharp/DocumentChunker.cs
@@ -141,16 +141,25 @@ namespace DoclingSharp
                         endTrim--;
                 }
 
-                // --- Add chunk if valid ---
                 if (startTrim <= endTrim)
                 {
                     int sliceLen = endTrim - startTrim + 1;
                     result.Add(new TextChunk(text.Substring(startTrim, sliceLen), startTrim, cut));
                 }
 
-                // advance with overlap
+                // advance
+                if (cut >= len)
+                {
+                    // we consumed the tail, break out
+                    break;
+                }
+
                 i = cut + (ChunkMaxCharacters - ChunkCharacterOverlap);
-                if (i > len) i = len;
+                if (i >= len)
+                {
+                    // ensure we don't miss the last partial bit
+                    i = len;
+                }
             }
 
             return result;


### PR DESCRIPTION
- Ensure the last segment of text is not dropped when input length is not a multiple of ChunkMaxCharacters.
- Adjusted chunk advancement logic to capture trailing text.